### PR TITLE
AKSI infra bootstrap: minimal FastAPI app + CI + Render config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+# Milana-backend (AKSI)
+
+Лёгкий backend на FastAPI для сервисов AKSI / Milana. Готов к деплою на Render / Fly.io / Railway.
+
+## Endpoints
+- `GET /health` — ok
+- `GET /version` — версия (`AKSI_VERSION`, по умолчанию `0.1.0`)
+- `POST /echo` — эхо JSON (`{"data":{...}}`)
+- `GET /aksi/metrics` — ok/ts/version
+- `GET /aksi/proof` — эпизодический SHA-256 (на основе timestamp)
+- `POST /aksi/proof/stable` — стабильный SHA-256, сохраняется в `PROOF_SHA256.txt`
+- `GET /aksi/logs` — последние события (ring buffer)
+- `POST /aksi/logs/append` — добавить событие (любая JSON-структура)
+- `GET /aksi/logs/export` — экспорт логов в `text/plain`
+
+## Быстрый старт
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+uvicorn app:app --host 0.0.0.0 --port 8000
+```
+
+## CORS
+Разрешённые источники задаются через `AKSI_CORS_ORIGINS` (CSV). По умолчанию: `https://milana808.github.io,http://localhost:3000,http://127.0.0.1:3000`.
+
+## Deploy
+### Render
+`render.yaml` уже включён. Создайте Web Service из репозитория.
+
+### Fly.io
+Есть `Dockerfile` и `fly.toml`.
+
+### Railway
+Есть `railway.json`.
+
+## Примеры
+```bash
+# health
+curl -s http://localhost:8000/health
+# версия
+curl -s http://localhost:8000/version
+# proof (stable)
+curl -s -X POST http://localhost:8000/aksi/proof/stable
+# logs
+curl -s -X POST http://localhost:8000/aksi/logs/append -H 'Content-Type: application/json' -d '{"event":"hello","payload":{"x":1}}'
+curl -s http://localhost:8000/aksi/logs
+```

--- a/app.py
+++ b/app.py
@@ -1,7 +1,8 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
-import os, hashlib, time, pathlib
+from collections import deque
+import os, hashlib, time, pathlib, json
 
 app = FastAPI(title="Milana Backend (AKSI)")
 
@@ -15,24 +16,42 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+# --- In-memory logs (ring buffer) ---
+LOG_CAP = int(os.getenv("AKSI_LOG_CAP", "200"))
+_logs = deque(maxlen=LOG_CAP)
+
+def _log(event: str, payload: dict | None = None):
+    _logs.append({
+        "ts": int(time.time()),
+        "event": event,
+        "payload": payload or {}
+    })
+
 class Echo(BaseModel):
     data: dict
 
 @app.get("/health")
 def health():
+    _log("health")
     return {"status": "ok"}
 
 @app.get("/version")
 def version():
-    return {"version": os.getenv("AKSI_VERSION", "0.1.0")}
+    ver = os.getenv("AKSI_VERSION", "0.1.0")
+    _log("version", {"version": ver})
+    return {"version": ver}
 
 @app.post("/echo")
 def echo(payload: Echo):
+    _log("echo", payload.model_dump())
     return payload.model_dump()
 
 @app.get("/aksi/metrics")
 def metrics():
-    return {"ok": True, "ts": int(time.time()), "version": os.getenv("AKSI_VERSION", "0.1.0")}
+    ver = os.getenv("AKSI_VERSION", "0.1.0")
+    data = {"ok": True, "ts": int(time.time()), "version": ver}
+    _log("metrics", data)
+    return data
 
 # --- Proof: stable-on-disk within container (regenerates on new deploy) ---
 PROOF_PATH = pathlib.Path("PROOF_SHA256.txt")
@@ -40,13 +59,39 @@ PROOF_PATH = pathlib.Path("PROOF_SHA256.txt")
 @app.get("/aksi/proof")
 def proof_ephemeral():
     payload = f"AKSI-PROOF:{int(time.time())}".encode()
-    return {"sha256": hashlib.sha256(payload).hexdigest(), "stable": False}
+    digest = hashlib.sha256(payload).hexdigest()
+    _log("proof_ephemeral", {"sha256": digest})
+    return {"sha256": digest, "stable": False}
 
 @app.post("/aksi/proof/stable")
 def proof_stable():
     if PROOF_PATH.exists():
-        return {"sha256": PROOF_PATH.read_text().strip(), "stable": True}
+        digest = PROOF_PATH.read_text().strip()
+        _log("proof_stable_read", {"sha256": digest})
+        return {"sha256": digest, "stable": True}
     payload = f"AKSI-PROOF:seed:{int(time.time())}".encode()
     digest = hashlib.sha256(payload).hexdigest()
     PROOF_PATH.write_text(digest)
+    _log("proof_stable_write", {"sha256": digest})
     return {"sha256": digest, "stable": True}
+
+# --- Logs API ---
+@app.get("/aksi/logs")
+def logs_list(limit: int = 100):
+    data = list(_logs)[-min(limit, LOG_CAP):]
+    return {"items": data, "count": len(data), "cap": LOG_CAP}
+
+@app.post("/aksi/logs/append")
+async def logs_append(req: Request):
+    body = await req.json() if req.headers.get("content-type","").startswith("application/json") else {"raw": await req.body()}
+    _log("append", body if isinstance(body, dict) else {"raw": str(body)})
+    return {"ok": True, "size": len(_logs)}
+
+@app.get("/aksi/logs/export")
+def logs_export():
+    lines = [json.dumps(x, ensure_ascii=False) for x in _logs]
+    return app.response_class(
+        content='
+'.join(lines),
+        media_type="text/plain; charset=utf-8"
+    )


### PR DESCRIPTION
Этот PR добавляет минимальный рабочий каркас бэкенда AKSI на FastAPI (health/version/echo), CI на GitHub Actions и базовую конфигурацию для деплоя на Render.

**Что внутри**
- `app.py` — FastAPI endpoints: `/health`, `/version`, `/echo`
- `requirements.txt` — pinned versions
- `render.yaml` — web service (Python, Uvicorn)
- `.github/workflows/ci.yml` — базовая проверка среды
- `README.md` — быстрый старт

**Дальше**
- По желанию добавим Dockerfile + Fly.io/Railway
- Подключим секреты `AKSI_VERSION` и API-ключи
- Привезём `/aksi/metrics` и `/aksi/proof` (SHA-256 + timestamp)
